### PR TITLE
fix: failing accessibility test with 0 violations

### DIFF
--- a/src/support/check/checkForAccessibilityIssues.js
+++ b/src/support/check/checkForAccessibilityIssues.js
@@ -31,7 +31,7 @@ export const checkForAccessibilityIssues = (level) => {
 		});
 	}, levels);
 
-	expect(results.value.violations, getErrorMessage(results.value.violations)).to.equal([]);
+	expect(results.value.violations, getErrorMessage(results.value.violations)).to.eql([]);
 };
 
 export const getErrorMessage = (violations) => {

--- a/test/support/check/checkForAccessibilityIssues.spec.js
+++ b/test/support/check/checkForAccessibilityIssues.spec.js
@@ -19,7 +19,7 @@ describe("checkForAccessibilityIssues", () => {
 
 		global.expect = jest.fn(() => ({
 			to: {
-				equal: jest.fn()
+				eql: jest.fn()
 			}
 		}));
 	});


### PR DESCRIPTION
we were using chai's `to.equal` which does strict object comparison.
If we had zero a11y violations, we were essentially doing `[] === []`
which is false. Instead, we need to do deep array comparison, hence
the change to use `.eql` instead.

fixes issue #13